### PR TITLE
Add jest tests for formatPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) to view the portfolio.
 
+## Running Tests
+
+Run the unit tests with Jest:
+
+```bash
+npm test
+```
+
 ## Features
 
 - Modern responsive design

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testPathIgnorePatterns: ['/node_modules/'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",
@@ -25,6 +26,12 @@
     "eslint-config-next": "15.3.1",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@types/jest": "^29.5.7",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.0.0"
   }
 }

--- a/src/app/component/TopBar.tsx
+++ b/src/app/component/TopBar.tsx
@@ -5,6 +5,11 @@ import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { useTheme } from "./theme-provider";
 
+export const formatPath = (path: string): string => {
+  if (path === "/") return "/Portfolio/Home";
+  return "/Portfolio" + path.replace(/\/(\w)/g, (_, char) => "/" + char.toUpperCase());
+};
+
 interface TopBarProps {
   onToggleSidebar: () => void;
   sidebarOpen: boolean;
@@ -14,15 +19,7 @@ const TopBar: React.FC<TopBarProps> = ({ onToggleSidebar, sidebarOpen }) => {
   const pathname = usePathname();
   const { theme, toggleTheme } = useTheme();
 
-  // Convert the pathname to a file explorer-style path
-  const formatPath = (path: string) => {
-    if (path === "/") return "/Portfolio/Home";
-    // Replace the first slash and capitalize each segment
-    return (
-      "/Portfolio" +
-      path.replace(/\/(\w)/g, (_, char) => "/" + char.toUpperCase())
-    );
-  };
+
 
   return (
     <div className="flex flex-col">
@@ -92,3 +89,4 @@ const TopBar: React.FC<TopBarProps> = ({ onToggleSidebar, sidebarOpen }) => {
 };
 
 export default TopBar;
+export { formatPath };

--- a/src/app/component/__tests__/TopBar.test.ts
+++ b/src/app/component/__tests__/TopBar.test.ts
@@ -1,0 +1,11 @@
+import { formatPath } from '../TopBar';
+
+describe('formatPath', () => {
+  it("returns '/Portfolio/Home' for root", () => {
+    expect(formatPath('/')).toBe('/Portfolio/Home');
+  });
+
+  it("capitalizes segments", () => {
+    expect(formatPath('/about')).toBe('/Portfolio/About');
+  });
+});


### PR DESCRIPTION
## Summary
- export `formatPath` for reuse
- set up jest with React Testing Library
- add tests for `formatPath`
- document how to run tests

## Testing
- `bun run test` *(fails: jest: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684538d18480832f93138b3a8bead265