### PR TITLE
Add blog section

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { blogPosts } from "@/content/blogPosts";
+
+export default function BlogPostPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const post = blogPosts.find((p) => p.slug === params.slug);
+  if (!post) return notFound();
+
+  return (
+    <div className="relative z-10 min-h-screen flex items-center justify-center p-4">
+      <div className="flex flex-col w-full max-w-3xl bg-white/10 backdrop-blur-md rounded-2xl border border-white/20 shadow-2xl p-6">
+        <Link
+          href="/blog"
+          className="text-white/70 hover:text-white transition-colors text-sm"
+        >
+          ← Back to Blog
+        </Link>
+
+        <h1 className="mt-3 text-3xl md:text-4xl font-bold text-white tracking-tight">
+          {post.title}
+        </h1>
+        <div className="mt-1 text-white/60 text-sm">{post.date}</div>
+
+        <div className="mt-6 whitespace-pre-wrap text-white/85 leading-relaxed">
+          {post.content}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,12 +3,14 @@ import { notFound } from "next/navigation";
 
 import { blogPosts } from "@/content/blogPosts";
 
-export default function BlogPostPage({
+export default async function BlogPostPage({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }) {
-  const post = blogPosts.find((p) => p.slug === params.slug);
+  const { slug } = await params;
+
+  const post = blogPosts.find((p) => p.slug === slug);
   if (!post) return notFound();
 
   return (

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+
+import { blogPosts } from "@/content/blogPosts";
+
+export const metadata = {
+  title: "Blog",
+};
+
+export default function BlogPage() {
+  return (
+    <div className="relative z-10 min-h-screen flex items-center justify-center p-4">
+      <div className="flex flex-col w-full max-w-3xl bg-white/10 backdrop-blur-md rounded-2xl border border-white/20 shadow-2xl p-6">
+        <div className="flex items-baseline justify-between gap-4 flex-wrap">
+          <h1 className="text-3xl md:text-4xl font-bold text-white tracking-tight">
+            Blog
+          </h1>
+          <p className="text-white/70 text-sm">Notes, learnings, and shipping logs.</p>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-4">
+          {blogPosts.map((post) => (
+            <article
+              key={post.slug}
+              className="rounded-xl border border-white/20 bg-white/5 p-4 hover:bg-white/10 transition-colors"
+            >
+              <div className="flex items-center justify-between gap-3 flex-wrap">
+                <h2 className="text-xl font-semibold text-white">
+                  <Link href={`/blog/${post.slug}`} className="hover:underline">
+                    {post.title}
+                  </Link>
+                </h2>
+                <span className="text-white/60 text-sm">{post.date}</span>
+              </div>
+              <p className="mt-2 text-white/80">{post.excerpt}</p>
+              <div className="mt-3">
+                <Link
+                  href={`/blog/${post.slug}`}
+                  className="inline-flex items-center justify-center rounded-lg bg-white/20 hover:bg-white/30 text-white px-3 py-1.5 transition-colors text-sm"
+                >
+                  Read
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="mt-6 text-white/70 text-sm">
+          Want this to be MDX later? I can wire that up next.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Tab tabs={["Home", "Contact"]} />
+        <Tab tabs={["Home", "Blog", "Contact"]} />
         <SkyBackground />
 
         <div className="fixed bottom-4 right-4 z-50">

--- a/src/content/blogPosts.ts
+++ b/src/content/blogPosts.ts
@@ -1,0 +1,28 @@
+export type BlogPost = {
+  slug: string;
+  title: string;
+  date: string; // YYYY-MM-DD
+  excerpt: string;
+  content: string;
+};
+
+export const blogPosts: BlogPost[] = [
+  {
+    slug: "why-i-built-this-portfolio",
+    title: "Why I built this portfolio",
+    date: "2026-02-03",
+    excerpt:
+      "A quick note on the file-explorer theme, what I wanted to show, and what I'm improving next.",
+    content:
+      "This is a placeholder post. Replace this string with real content (or switch to MDX later).",
+  },
+  {
+    slug: "what-im-learning-right-now",
+    title: "What I'm learning right now",
+    date: "2026-02-03",
+    excerpt:
+      "A running list of topics I'm deepening: Next.js App Router, testing, and building small tools.",
+    content:
+      "This is a placeholder post. Add your current learning notes here.",
+  },
+];


### PR DESCRIPTION
Adds a simple Blog section:

- Adds a **Blog** tab to the top navigation
- Adds `/blog` index page with placeholder posts
- Adds dynamic post route `/blog/[slug]` backed by a small `blogPosts` data file

This is intentionally lightweight (no MDX yet) so you can iterate quickly.